### PR TITLE
Feat/assertion

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -17,6 +17,18 @@ describe('createBindingRequest()', () => {
     const msg = createBindingRequest();
     expect(msg).toBeInstanceOf(StunMessage);
   });
+
+  test('throws if invalid tid passed', () => {
+    expect(() => {
+      createBindingRequest('invalid');
+    }).toThrow();
+  });
+
+  test('does not throw if valid tid passed', () => {
+    expect(() => {
+      createBindingRequest(generateTransactionId());
+    }).not.toThrow();
+  });
 });
 
 describe('generateTransactionId()', () => {

--- a/__tests__/utils/buffer.test.ts
+++ b/__tests__/utils/buffer.test.ts
@@ -1,0 +1,18 @@
+import * as utils from '../../src/utils';
+
+describe('bufferXor()', () => {
+  test('xor buffer properly', () => {
+    const b1 = Buffer.from('0f00f0', 'hex');
+    const b2 = Buffer.from('00f00f', 'hex');
+    const ex = Buffer.from('0ff0ff', 'hex');
+    expect(utils.bufferXor(b1, b2).equals(ex)).toBeTruthy();
+  });
+
+  test('throws if buffers have different length', () => {
+    expect(() => {
+      const b1 = Buffer.from([1, 2, 3]);
+      const b2 = Buffer.from([1, 2, 3, 4]);
+      utils.bufferXor(b1, b2);
+    }).toThrow();
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,12 @@ export function createBlank(): StunMessage {
 }
 
 export function createBindingRequest(tid?: string): StunMessage {
+  if (tid && tid.length !== 24) {
+    throw new TypeError(
+      '[webrtc-stun] The tid must be hex string which length is 24',
+    );
+  }
+
   return new StunMessage(
     new Header(STUN_MESSAGE_TYPE.BINDING_REQUEST, tid || generateTId(12)),
   );

--- a/src/message.ts
+++ b/src/message.ts
@@ -99,7 +99,7 @@ export class StunMessage {
   }
 
   setMappedAddressAttribute(rinfo: RemoteInfo): StunMessage {
-    this.addAttribute(
+    this.attributes.push(
       new MappedAddressAttribute(rinfo.family, rinfo.port, rinfo.address),
     );
     return this;
@@ -111,7 +111,7 @@ export class StunMessage {
   }
 
   setUsernameAttribute(name: string): StunMessage {
-    this.addAttribute(new UsernameAttribute(name));
+    this.attributes.push(new UsernameAttribute(name));
     return this;
   }
   getUsernameAttribute(): UsernamePayload | null {
@@ -121,7 +121,7 @@ export class StunMessage {
   setMessageIntegrityAttribute(integrityKey: string): StunMessage {
     // add dummy first to disguise total length
     const attr = new MessageIntegrityAttribute();
-    this.addAttribute(attr);
+    this.attributes.push(attr);
 
     const $integrity = generateIntegrity(this.toBuffer(), integrityKey);
     attr.loadBuffer($integrity);
@@ -137,7 +137,7 @@ export class StunMessage {
   setFingerprintAttribute(): StunMessage {
     // add dummy first to disguise total length
     const attr = new FingerprintAttribute();
-    this.addAttribute(attr);
+    this.attributes.push(attr);
 
     const $fp = generateFingerprint(this.toBuffer());
     attr.loadBuffer($fp);
@@ -151,7 +151,7 @@ export class StunMessage {
   }
 
   setXorMappedAddressAttribute(rinfo: RemoteInfo): StunMessage {
-    this.addAttribute(
+    this.attributes.push(
       new XorMappedAddressAttribute(rinfo.family, rinfo.port, rinfo.address),
     );
     return this;
@@ -163,7 +163,7 @@ export class StunMessage {
   }
 
   setSoftwareAttribute(name: string): StunMessage {
-    this.addAttribute(new SoftwareAttribute(name));
+    this.attributes.push(new SoftwareAttribute(name));
     return this;
   }
   getSoftwareAttribute(): SoftwarePayload | null {
@@ -254,10 +254,6 @@ export class StunMessage {
     }
 
     return true;
-  }
-
-  private addAttribute(attr: Attribute) {
-    this.attributes.push(attr);
   }
 
   private validateMessageIntegrity(integrityKey: string): boolean {

--- a/src/message.ts
+++ b/src/message.ts
@@ -223,7 +223,7 @@ export class StunMessage {
       if (loadedAttrType.has(type)) {
         continue;
       }
-      // ignore rest attrs appeared after MESSAGE_INTEGRITY except for FINGERPRINT
+      // ignore rest attrs will appearing after MESSAGE_INTEGRITY except for FINGERPRINT
       if (
         loadedAttrType.has(STUN_ATTRIBUTE_TYPE.MESSAGE_INTEGRITY) &&
         type !== STUN_ATTRIBUTE_TYPE.FINGERPRINT
@@ -232,7 +232,7 @@ export class StunMessage {
       }
 
       const attr = this.getBlankAttributeByType(type);
-      // skip not supported
+      // skip not supported attr
       if (attr === null) {
         console.log(
           `[webrtc-stun] Attr type 0x${type.toString(

--- a/src/utils/buffer.ts
+++ b/src/utils/buffer.ts
@@ -1,5 +1,10 @@
 export function bufferXor(a: Buffer, b: Buffer): Buffer {
-  // a and b should have same length
+  if (a.length !== b.length) {
+    throw new TypeError(
+      '[webrtc-stun] You can not XOR buffers which length are different',
+    );
+  }
+
   const length = a.length;
   const buffer = Buffer.allocUnsafe(length);
 


### PR DESCRIPTION
- [x] assert `tid` length
- [x] assert in `bufferXor()`
- [x] ignore attrs appearing after `MESSAGE-INTEGRITY` except for `FINGERPRINT`